### PR TITLE
Firmware v1.3 with Babel-Babel related fixes and updated external links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__
 
 # Temporary
 *.log
+*.tmp
 
 # Eclipse
 .metadata

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # [Zubax Babel](https://zubax.com/products/babel)
 
-[![Join the chat at https://gitter.im/Zubax/general](https://img.shields.io/badge/GITTER-join%20chat-green.svg)](https://gitter.im/Zubax/general)
+[![Forum](https://img.shields.io/discourse/https/forum.zubax.com/users.svg?color=e00000)](https://forum.zubax.com)
+[![Forum](https://img.shields.io/discourse/https/forum.uavcan.org/users.svg?color=1700b3)](https://forum.uavcan.org)
 
 Zubax Babel is a high performance USB-CAN and UART-CAN adapter that can be used as a
 standalone device or as an embeddable module for original equipment manufacturers (OEM).
@@ -8,8 +9,7 @@ standalone device or as an embeddable module for original equipment manufacturer
 Babel implements the quasi-standard SLCAN protocol (aka LAWICEL protocol) that is understood by
 majority of CAN software products, including the Linux SocketCAN framework.
 If Babel is used with [UAVCAN](http://uavcan.org) networks,
-we recommend to use the [UAVCAN GUI Tool](http://uavcan.org/GUI_Tool),
-which fully supports all of the advanced features available in Zubax Babel.
+we recommend to use the [Yakut CLI tool](https://github.com/UAVCAN/yakut).
 
 [**ZUBAX BABEL HOMEPAGE**](https://zubax.com/products/babel).
 
@@ -36,9 +36,6 @@ relevant for the CAN frame timestamp recovery problem on the host side:
 This algoritm is employed in the SLCAN backend in [PyUAVCAN library](http://uavcan.org/Implementations/Pyuavcan).
 
 ## Firmware
-
-If you're not running Linux or OSX natively, you can use
-[Bistromathic - a Linux virtual machine pre-configured for embedded development](https://kb.zubax.com/x/KIEh).
 
 ### Change Log
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Initial release.
 
 ### Building
 
-Install ARM GCC toolchain version 6.3.
+Install ARM GCC toolchain of the correct version (consult with `main.cpp`).
 Clone this repository, init all submodules (`git submodule update --init --recursive`),
 then execute the following from the repository root:
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ If you're not running Linux or OSX natively, you can use
 
 ### Change Log
 
+#### v1.3
+
+* Fix a hardware compatibility problem for Babel-Babel:
+  enable the built-in pull-up resistor on the CAN power disable line.
+
 #### v1.2
 
 * Added a new CLI command: `gpio`. This command allows one to control the SMD GPIO pads via USB/UART.

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -21,7 +21,7 @@ PROJECT = com.zubax.babel
 
 HW_VERSION = 1
 BL_VERSION_MAJOR = 1
-BL_VERSION_MINOR = 1
+BL_VERSION_MINOR = 2
 
 APPLICATION_OFFSET = 32768
 
@@ -66,7 +66,8 @@ DEBUG_OPT = -Os -g3 -DDISABLE_WATCHDOG=1
 
 LDSCRIPT = ld.ld
 
-CWARN += -Wshadow -Wpointer-arith -Wno-packed -Wno-attributes -Wno-error=undef -Wno-error=shadow
+CWARN += -Wshadow -Wpointer-arith -Wno-packed -Wno-attributes -Wno-error=undef \
+         -Wno-error=shadow -Wno-error=implicit-fallthrough -Wno-class-memaccess -Wno-bool-operation
 CPPWARN += $(CWARN)
 
 include zubax_chibios/rules_stm32f37x.mk

--- a/bootloader/src/main.cpp
+++ b/bootloader/src/main.cpp
@@ -251,6 +251,6 @@ int main()
 #define MATCH_GCC_VERSION(major, minor, patch)  \
     ((__GNUC__ == (major)) && (__GNUC_MINOR__ == (minor)) && (__GNUC_PATCHLEVEL__ == (patch)))
 
-#if !(MATCH_GCC_VERSION(6, 3, 1))
+#if !(MATCH_GCC_VERSION(10, 3, 1))
 # error "This compiler is not supported"
 #endif

--- a/bootloader/src/sys/board.h
+++ b/bootloader/src/sys/board.h
@@ -162,7 +162,7 @@
                                      PIN_PUPDR_PULLDOWN(GPIOA_PIN_5) |\
                                      PIN_PUPDR_PULLDOWN(GPIOA_PIN_6) |\
                                      PIN_PUPDR_PULLDOWN(7) |\
-                                     PIN_PUPDR_FLOATING(GPIOA_CAN_POWER_DIS) |\
+                                     PIN_PUPDR_PULLUP(GPIOA_CAN_POWER_DIS) |\
                                      PIN_PUPDR_FLOATING(GPIOA_UART1_TX) |\
                                      PIN_PUPDR_PULLUP(GPIOA_UART1_RX) |\
                                      PIN_PUPDR_FLOATING(GPIOA_USB_DM) |\

--- a/docs/datasheet/Zubax_Babel_Datasheet.tex
+++ b/docs/datasheet/Zubax_Babel_Datasheet.tex
@@ -1319,7 +1319,7 @@ Intervals and default values may change in newer revisions of the firmware or th
     \tabularnewline
 }%
 \newenvironment{CfgParamIndex}[1]{%
-    \begin{ZubaxTableWrapper}{#1}
+    \begin{ZubaxTableWrapper}[wide]{#1}
     \setlength\tabcolsep{2.5pt}
     \begin{ZubaxWrappedTable}{@{} l c l l | c c c | X @{}}
     Name & \makecell[cb]{SLCAN\\alias} & \makecell[lb]{Takes\\effect at} & Pages & Min & Max & Def. & Description \\

--- a/docs/datasheet/Zubax_Babel_Datasheet.tex
+++ b/docs/datasheet/Zubax_Babel_Datasheet.tex
@@ -1,5 +1,5 @@
 %
-% Copyright (c) 2017-2019  Zubax Robotics  <info@zubax.com>
+% Copyright (c) 2017  Zubax Robotics  <info@zubax.com>
 %
 % Distributed under BY-NC-ND (attribution required, non-commercial use only, no derivatives).
 %
@@ -65,7 +65,7 @@ There is a wide selection of software products that can communicate with SLCAN-c
 \begin{itemize}
     \item General-purpose USB-CAN or UART-CAN adapter.
     \item Diagnostic, monitoring, and development tool for \href{http://uavcan.org}{UAVCAN} networks.
-          We recommend the UAVCAN GUI Tool for use with UAVCAN applications.
+          We recommend Yakut for use with UAVCAN applications.
     \item Generic CAN/UAVCAN development board.
     \item Programmable CAN unit in OEM applications.
 \end{itemize}

--- a/docs/datasheet/clean.ps1
+++ b/docs/datasheet/clean.ps1
@@ -1,0 +1,4 @@
+#!/usr/bin/env pwsh
+
+rm -f *.aux *.lof *.lot *.out *.toc *.log *.fls *.gz *-converted-to.* *.cache
+rm -rf _minted-*

--- a/docs/datasheet/compile.ps1
+++ b/docs/datasheet/compile.ps1
@@ -1,0 +1,6 @@
+#!/usr/bin/env pwsh
+param ($texfile='Zubax_Babel_Datasheet.tex')
+Set-Location (Split-Path $script:MyInvocation.MyCommand.Path)
+pdflatex --halt-on-error --shell-escape $texfile
+pdflatex --halt-on-error --shell-escape $texfile
+pdflatex --halt-on-error --shell-escape $texfile

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -21,7 +21,7 @@ PROJECT = com.zubax.babel
 
 HW_VERSION_MAJOR = 1
 FW_VERSION_MAJOR = 1
-FW_VERSION_MINOR = 2
+FW_VERSION_MINOR = 3
 
 #
 # Application
@@ -69,7 +69,8 @@ DEBUG_OPT = -O2 -g3 -DDISABLE_WATCHDOG=1
 
 LDSCRIPT = ld.ld
 
-CWARN += -Wshadow -Wpointer-arith -Wno-packed -Wno-attributes -Wno-error=undef -Wno-error=shadow
+CWARN += -Wshadow -Wpointer-arith -Wno-packed -Wno-attributes -Wno-error=undef \
+         -Wno-error=shadow -Wno-error=implicit-fallthrough -Wno-class-memaccess -Wno-bool-operation
 CPPWARN += $(CWARN)
 
 #
@@ -85,26 +86,26 @@ BOOTLOADER_IMAGE := $(BOOTLOADER_DIR)/build/com.zubax.babel.bin
 POST_MAKE_ALL_RULE_HOOK: build/$(PROJECT).bin build/$(PROJECT).elf
 	# Building the bootloader
 	+cd $(BOOTLOADER_DIR) && make RELEASE=$(RELEASE)
-	
+
 	# Removing previous build outputs that could use a different git hash
 	rm -rf build/*.application.bin build/*.compound.bin
-	
+
 	# Generating compound image with embedded bootloader
 	cd build && dd if=/dev/zero bs=$(BOOTLOADER_SIZE) count=1 | tr "\000" "\377" >padded_bootloader.tmp.bin
 	cd build && dd if=$(BOOTLOADER_IMAGE) of=padded_bootloader.tmp.bin conv=notrunc
 	cd build && cat padded_bootloader.tmp.bin $(PROJECT).bin >$(COMPOUND_IMAGE_FILE)
-	
+
 	# Generating the signed image for the bootloader
 	cd build && ../zubax_chibios/tools/make_boot_descriptor.py $(PROJECT).bin $(PROJECT) $(HW_VERSION_MAJOR)       \
 	                                                           --also-patch-descriptor-in=$(PROJECT).elf           \
 	                                                           --also-patch-descriptor-in=$(COMPOUND_IMAGE_FILE)
-	
+
 	# Injecting the bootloader into the final ELF; note that we're using unpadded bootloader to preserve signature
 	cd build && $(TOOLCHAIN_PREFIX)-objcopy --add-section bootloader=$(BOOTLOADER_IMAGE)   \
 	                                        --set-section-flags bootloader=load,alloc      \
 	                                        --change-section-address bootloader=0x08000000 \
 	                                        $(PROJECT).elf compound.elf
-	
+
 	# Removing temporary files
 	cd build && rm -f $(PROJECT).bin $(PROJECT).elf *.hex *.tmp.bin
 

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -64,8 +64,8 @@ USE_LTO := yes
 SERIAL_CLI_PORT_NUMBER = 1
 
 RELEASE ?= 0
-RELEASE_OPT = -O3 -fomit-frame-pointer # -g3    # -g3 is needed for profiling
-DEBUG_OPT = -O2 -g3 -DDISABLE_WATCHDOG=1
+RELEASE_OPT = -O3 -fomit-frame-pointer -ggdb -fno-strict-aliasing
+DEBUG_OPT = -O2 -ggdb -DDISABLE_WATCHDOG=1 -fno-strict-aliasing
 
 LDSCRIPT = ld.ld
 

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -1146,6 +1146,7 @@ int main()
 #define MATCH_GCC_VERSION(major, minor, patch)  \
     ((__GNUC__ == (major)) && (__GNUC_MINOR__ == (minor)) && (__GNUC_PATCHLEVEL__ == (patch)))
 
-#if !(MATCH_GCC_VERSION(6, 3, 1))
+#if !(MATCH_GCC_VERSION(10, 3, 1))
+# error __GNUC__
 # error "This compiler is not supported"
 #endif


### PR DESCRIPTION
Release artifacts attached:

- [Datasheet](https://github.com/Zubax/zubax_babel/files/7746675/Zubax_Babel_Datasheet.pdf)
- [Firmware binaries](https://github.com/Zubax/zubax_babel/files/7747096/build.tar.gz)


